### PR TITLE
Refine the use of the user webcam; include image in results component

### DIFF
--- a/app/assets/styles/main.css
+++ b/app/assets/styles/main.css
@@ -165,6 +165,12 @@ video {
 
 
 /*EMOTION RESULTS*/
+.result-img {
+  margin: 20px;
+  border: 10px solid #629EAE;
+  border-radius: 50px;
+}
+
 .results {
   color: rgba(111, 157, 172, 1);
 }

--- a/app/components/EmotionResults/EmotionResults.js
+++ b/app/components/EmotionResults/EmotionResults.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { analyzeResponse } from '../../helper.js';
 
-export const EmotionResults = ({ results }) => {
+export const EmotionResults = ({ results, url }) => {
   const noResults = () => {
     return (
       <h2 className='no-results'>Take a picture to see your expression!</h2>
@@ -12,6 +12,7 @@ export const EmotionResults = ({ results }) => {
     let emotionsForDisplay = analyzeResponse(results);
     return (
       <div>
+        <img className='result-img' src={url} height='175px' width='150px' />
         <h2 className='results'>your expression is:</h2>
         {
           emotionsForDisplay.map((emotionObject, index) => {

--- a/app/components/ImageCapture/ImageCapture.js
+++ b/app/components/ImageCapture/ImageCapture.js
@@ -23,7 +23,8 @@ export default class ImageCapture extends Component {
   }
 
   endImageCapture(video, canvas) {
-    video.pause();
+    let media = video.srcObject;
+    media.getVideoTracks()[0].stop()
   }
 
   dataURItoBlob(dataURI) {
@@ -41,18 +42,14 @@ export default class ImageCapture extends Component {
     const ctx = canvas.getContext('2d');
 
     ctx.drawImage(video, 350, 20, 600, 700, 0, 0, 300, 350);
+    this.endImageCapture(video, canvas);
 
     let dataUrl = canvas.toDataURL("image/jpeg");
     let blobData = this.dataURItoBlob(dataUrl);
+
+    this.props.getImageURL(dataUrl);
     this.props.analyzeEmotions(blobData);
-    this.endImageCapture(video, canvas);
   }
-
-
-
-
-
-
 
   render() {
     return (

--- a/app/components/Play/Play.js
+++ b/app/components/Play/Play.js
@@ -7,8 +7,13 @@ export default class Play extends Component {
   constructor() {
     super()
     this.state = {
-      emotions: []
+      emotions: [],
+      canvasURL: ''
     }
+  }
+
+  getImageURL(url) {
+    this.setState({canvasURL: url})
   }
 
   analyzeEmotions(faceBlob) {
@@ -37,8 +42,10 @@ export default class Play extends Component {
     return (
       <article className='play'>
         <PickEmotion />
-        <ImageCapture analyzeEmotions={this.analyzeEmotions.bind(this)} />
-        <EmotionResults results={this.state.emotions} />
+        <ImageCapture analyzeEmotions={this.analyzeEmotions.bind(this)}
+                      getImageURL={this.getImageURL.bind(this)}/>
+        <EmotionResults results={this.state.emotions}
+                        url={this.state.canvasURL} />
       </article>
     )
   }


### PR DESCRIPTION
Changed the "end capture" function in Play component to actually end the webcam media stream, instead of just pausing the video playback of the stream. This fixes buggy functionality of the camera and Image Capture buttons.

This branch also adds an image to the Emotion Results component, since ending the media stream results in a black video display.