### PR TITLE
Remove the pseudostate focus outline on buttons - closes #28

### DIFF
--- a/app/assets/styles/main.css
+++ b/app/assets/styles/main.css
@@ -17,6 +17,10 @@ article {
 }
 
 /*GLOBAL*/
+button:focus {
+  outline: rgba(0, 0, 0, 0);
+}
+
 .hidden {
   display: none;
 }

--- a/app/components/App/App.js
+++ b/app/components/App/App.js
@@ -6,7 +6,6 @@ import Play from '../Play/Play';
 import { Learn } from '../Learn/Learn';
 
 class App extends Component {
-
   render() {
     return (
       <Router>
@@ -18,7 +17,9 @@ class App extends Component {
             <Route exact path='/' component={Play} />
             <Route exact path='/instructions' component={Instructions}/>
             <Route path='/learn' component={Learn} />
-            <p className='copyright-notice'>&#169; 2017 Leta Keane</p>
+            <footer>
+              <p className='copyright-notice'>&#169; 2017 Leta Keane</p>            
+            </footer>
         </div>
       </Router>
     )

--- a/app/components/App/App.test.js
+++ b/app/components/App/App.test.js
@@ -4,7 +4,6 @@ import App from './App';
 import { shallow, mount } from 'enzyme';
 
 describe('App component tests', () => {
-
   it('renders without crashing', () => {
     const div = document.createElement('div');
     ReactDOM.render(<App />, div);

--- a/app/components/EmotionResults/EmotionResults.js
+++ b/app/components/EmotionResults/EmotionResults.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { analyzeResponse } from '../../helper.js';
+import analyzeResponse from '../../lib/analyzeResponse.js';
 
 export const EmotionResults = ({ results, url }) => {
   const noResults = () => {

--- a/app/components/ImageCapture/ImageCapture.test.js
+++ b/app/components/ImageCapture/ImageCapture.test.js
@@ -20,12 +20,14 @@ describe('ImageCapture component tests', () => {
     expect(wrapper.state()).toEqual(expectedState);
   })
 
-  it.skip('should begin image capture on button click', () => {
+  it('should begin image capture on button click', () => {
+    const mockFn = jest.fn();
+    ImageCapture.prototype.beginImageCapture = mockFn
     const wrapper = shallow(<ImageCapture />);
     const startButton = wrapper.find('.start-capture');
     startButton.simulate('click');
 
-    expect(wrapper.beginImageCapture).toHaveBeenCalledTimes(1);
+    expect(mockFn).toHaveBeenCalledTimes(1);
   })
 
 

--- a/app/lib/analyzeResponse.js
+++ b/app/lib/analyzeResponse.js
@@ -1,10 +1,10 @@
 const analyzeResponse = (data) => {
-  let scores = data[0].scores;
-  let emotions = Object.keys(scores);
-  let sortedEmotions = emotions.sort((a, b) => {
+  const scores = data[0].scores;
+  const emotions = Object.keys(scores);
+  const sortedEmotions = emotions.sort((a, b) => {
     return scores[b] - scores[a];
   })
-  let emotionDisplay = sortedEmotions.map(emotion => {
+  const emotionDisplay = sortedEmotions.map(emotion => {
     if (scores[emotion] > 0.49) {
       return {quantifier: 'mostly',
               emotion: emotion.toLowerCase()}

--- a/app/lib/analyzeResponse.js
+++ b/app/lib/analyzeResponse.js
@@ -1,4 +1,4 @@
-export const analyzeResponse = (data) => {
+const analyzeResponse = (data) => {
   let scores = data[0].scores;
   let emotions = Object.keys(scores);
   let sortedEmotions = emotions.sort((a, b) => {
@@ -15,3 +15,5 @@ export const analyzeResponse = (data) => {
   })
   return emotionDisplay
 }
+
+export default analyzeResponse;


### PR DESCRIPTION
## What's this PR do?

_Remove the outline from the :focus pseudoselector._

## Pre-Merge TODOs
 - [x] Screenshots Included

## Learning

_Had to google to double check how to target the focus pseudoselector._
_Opened up the dev tools to see how :focus was styled (spoiler alert: it just has a prop of "outline"._

## Where should the reviewer start?

_Not much to review!_

## Any background context you want to provide?

## Screenshots (if appropriate)
Before:
![before, with focus outline](http://i.imgur.com/EvsQuoU.png)

After:
![after, with transparent focus outline](http://i.imgur.com/Z8joGhk.png)

Focus!
![FOCUS!!](https://media.giphy.com/media/yVTjrM7Oi4Ofm/giphy.gif)
![FOCUS!!!](https://media.giphy.com/media/BDYADzX16SrEk/giphy.gif)
![FOCUS!!!!](https://media.giphy.com/media/14afmHqKZ3ctsk/giphy.gif)