### PR TITLE
WIP: Edit the text of the top button in ImageCapture - closes issue #29

### DIFF
--- a/app/assets/styles/main.css
+++ b/app/assets/styles/main.css
@@ -181,10 +181,10 @@ video {
 .face-oval {
   width: 150px;
   height: 200px;
-  border: 2px dashed rgba(237, 205, 156, 0.5);
-  -moz-border-radius: 70px / 90px;
-	-webkit-border-radius: 70px / 90px;
-	border-radius: 70px / 90px;
+  border: 8px dashed rgba(237, 205, 156, 0.3);
+  -moz-border-radius: 85px / 100px;
+	-webkit-border-radius: 85px / 100px;
+	border-radius: 85px / 100px;
   position: absolute;
   top: 150px;
   left: 50%;

--- a/app/components/ImageCapture/ImageCapture.js
+++ b/app/components/ImageCapture/ImageCapture.js
@@ -55,7 +55,7 @@ export default class ImageCapture extends Component {
     return (
       <article className='image-capture'>
         <button className='start-capture'
-                onClick={() => this.beginImageCapture()}>Start video</button>
+                onClick={() => this.beginImageCapture()}>start camera</button>
         <video autoPlay muted='true' height='350px' width='300px'></video>
         <div className='face-oval'></div>
         <button className='take-picture'


### PR DESCRIPTION
## What's this PR do?

_Adjust the text of the top button in ImageCapture.js to read 'start camera' (to match the lowercase aesthetic of the app as a whole) instead the less clear 'Start video'._

## Where should the reviewer start?

_Does this text make more sense? The user doesn't necessarily think of this as a video; it's just the camera. I also hope to clarify that the user must hit the 'start camera' button before the 'take picture' button._

## Screenshots (if appropriate)
Before:
![before](http://i.imgur.com/scU0yYZ.png)

After:
![after](http://i.imgur.com/bED1jD4.png)