### PR TITLE
Fix width of the learn more links in EmotionResults

### DIFF
--- a/app/assets/styles/main.css
+++ b/app/assets/styles/main.css
@@ -233,10 +233,11 @@ video {
   align-items: center;
   justify-content: center;
   height: 50px;
+  width: 65%;
   background-color: rgba(237, 205, 156, 1);
   color: white;
   border-radius: 50px;
-  margin-bottom: 30px;
+  margin: 0 auto 30px auto;
 }
 
 .learn-more-link:hover {


### PR DESCRIPTION
Very small PR: made sure the learn-more-links in EmotionResults had a max-width that looked good.

Before:
![before](http://i.imgur.com/rteHlaB.png)

After:
![after](http://i.imgur.com/nUIgS44.png)